### PR TITLE
fix: normalize daily_refetch module name string

### DIFF
--- a/modules/daily_refetch/daily_refetch.go
+++ b/modules/daily_refetch/daily_refetch.go
@@ -31,5 +31,5 @@ func NewModule(
 
 // Name implements modules.Module
 func (m *Module) Name() string {
-	return "daily refetch"
+	return "daily_refetch"
 }

--- a/modules/daily_refetch/handle_periodic_operations.go
+++ b/modules/daily_refetch/handle_periodic_operations.go
@@ -14,13 +14,13 @@ import (
 )
 
 func (m *Module) RegisterPeriodicOperations(scheduler *gocron.Scheduler) error {
-	log.Debug().Str("module", "daily refetch").Msg("setting up periodic tasks")
+	log.Debug().Str("module", "daily_refetch").Msg("setting up periodic tasks")
 
 	// Setup a cron job to run every midnight
 	if _, err := scheduler.Every(1).Day().At("00:00").Do(func() {
 		m.refetchMissingBlocks()
 	}); err != nil {
-		return fmt.Errorf("error while setting up daily refetch periodic operation: %s", err)
+		return fmt.Errorf("error while setting up daily_refetch periodic operation: %s", err)
 	}
 
 	return nil
@@ -28,7 +28,7 @@ func (m *Module) RegisterPeriodicOperations(scheduler *gocron.Scheduler) error {
 
 // refetchMissingBlocks checks for missing blocks from one day ago and refetches them
 func (m *Module) refetchMissingBlocks() error {
-	log.Trace().Str("module", "daily refetch").Str("refetching", "blocks").
+	log.Trace().Str("module", "daily_refetch").Str("refetching", "blocks").
 		Msg("refetching missing blocks")
 
 	latestBlock, err := m.node.LatestHeight()


### PR DESCRIPTION
## Summary
- Replace the module identifier string `"daily refetch"` with `"daily_refetch"` in log fields and error messages emitted by the `daily_refetch` module.
- Aligns the module name with the convention used by every other module in this codebase (e.g. `bank`, `staking`), which use a single-token, whitespace-free identifier.
- Touches `Module.Name()`, the `log.Debug` / `log.Trace` `"module"` fields, and the error message returned when the periodic scheduler registration fails.

## Why
- A whitespace in the module identifier diverges from the rest of the codebase and complicates log aggregation / filtering on downstream pipelines (Loki, ELK, etc.) where the value is often used as a label or tag.
- This is a pure string-label change; no business logic or runtime behavior is affected.

## Changes
- `modules/daily_refetch/daily_refetch.go`
  - `Module.Name()` now returns `"daily_refetch"`.
- `modules/daily_refetch/handle_periodic_operations.go`
  - `RegisterPeriodicOperations` debug log uses `"module": "daily_refetch"`.
  - Scheduler registration error message uses `daily_refetch` instead of `daily refetch`.
  - `refetchMissingBlocks` trace log uses `"module": "daily_refetch"`.

## Test plan
- [ ] `go build ./...` passes.
- [ ] Run the node and verify logs are emitted under `module=daily_refetch`.
- [ ] Audit external log dashboards / alert rules for any reference to the old `"daily refetch"` label and update them if present.