### PR TITLE
fix: restore proposal_type column and v0.50.x bugfixes

### DIFF
--- a/database/gov.go
+++ b/database/gov.go
@@ -111,7 +111,7 @@ INSERT INTO proposal(
 		accounts = append(accounts, types.NewAccount(proposal.Proposer))
 
 		// Prepare the proposal query
-		vi := i * 11
+		vi := i * 12
 		proposalsQuery += fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d),",
 			vi+1, vi+2, vi+3, vi+4, vi+5, vi+6, vi+7, vi+8, vi+9, vi+10, vi+11, vi+12)
 		var proposalType string
@@ -130,7 +130,7 @@ INSERT INTO proposal(
 					return fmt.Errorf("error unmarshalling proposal msg for type extraction: %s", err)
 				}
 				if t, ok := msgMap["@type"].(string); ok {
-					proposalType = t
+					proposalType = strings.TrimPrefix(t, "/")
 				} else {
 					proposalType = ""
 				}

--- a/database/gov_test.go
+++ b/database/gov_test.go
@@ -201,7 +201,7 @@ func (suite *DbTestSuite) TestBigDipperDb_SaveProposals() {
 			"Proposal Description 2",
 			"Proposal Metadata 2",
 			"[]",
-			"cosmos.gov.v1.MsgUpdateParams",
+			"",
 			time.Date(2020, 1, 2, 00, 00, 00, 000, time.UTC),
 			time.Date(2020, 1, 2, 01, 00, 00, 000, time.UTC),
 			testutils.NewTimePointer(time.Date(2020, 1, 2, 02, 00, 00, 000, time.UTC)),

--- a/database/schema/08-gov.sql
+++ b/database/schema/08-gov.sql
@@ -13,6 +13,7 @@ CREATE TABLE proposal
     description       TEXT      NOT NULL,
     metadata          TEXT      NOT NULL,
     content           JSONB     NOT NULL DEFAULT '[]'::JSONB,
+    proposal_type     TEXT      NOT NULL DEFAULT '',
     submit_time       TIMESTAMP NOT NULL,
     deposit_end_time  TIMESTAMP,
     voting_start_time TIMESTAMP,

--- a/modules/daily_refetch/daily_refetch.go
+++ b/modules/daily_refetch/daily_refetch.go
@@ -31,5 +31,5 @@ func NewModule(
 
 // Name implements modules.Module
 func (m *Module) Name() string {
-	return "daily refetch"
+	return "daily_refetch"
 }

--- a/modules/daily_refetch/handle_periodic_operations.go
+++ b/modules/daily_refetch/handle_periodic_operations.go
@@ -14,13 +14,13 @@ import (
 )
 
 func (m *Module) RegisterPeriodicOperations(scheduler *gocron.Scheduler) error {
-	log.Debug().Str("module", "daily refetch").Msg("setting up periodic tasks")
+	log.Debug().Str("module", "daily_refetch").Msg("setting up periodic tasks")
 
 	// Setup a cron job to run every midnight
 	if _, err := scheduler.Every(1).Day().At("00:00").Do(func() {
 		m.refetchMissingBlocks()
 	}); err != nil {
-		return fmt.Errorf("error while setting up daily refetch periodic operation: %s", err)
+		return fmt.Errorf("error while setting up daily_refetch periodic operation: %s", err)
 	}
 
 	return nil
@@ -28,7 +28,7 @@ func (m *Module) RegisterPeriodicOperations(scheduler *gocron.Scheduler) error {
 
 // refetchMissingBlocks checks for missing blocks from one day ago and refetches them
 func (m *Module) refetchMissingBlocks() error {
-	log.Trace().Str("module", "daily refetch").Str("refetching", "blocks").
+	log.Trace().Str("module", "daily_refetch").Str("refetching", "blocks").
 		Msg("refetching missing blocks")
 
 	latestBlock, err := m.node.LatestHeight()


### PR DESCRIPTION
## Summary
Bundles two unrelated fixes uncovered while running `make test-unit` on `cosmos/v0.50.x`.

### 1. `daily_refetch` module name normalization
- Replace `"daily refetch"` (with whitespace) with `"daily_refetch"` in the module's log fields and the scheduler-registration error message.
- Aligns this module identifier with the convention used everywhere else in the codebase (`bank`, `staking`, ...).

### 2. Restore the `proposal_type` column and repair `SaveProposals`
The v5 migration intentionally preserves the `proposal_type` column on existing chains, but the public `CREATE TABLE proposal` definition was missing it, so every proposal-related test on a fresh schema failed. Two latent bugs surfaced once the schema lined up:
- The placeholder-index multiplier in `SaveProposals` was still `i*11` after the column count grew to 12, causing every row past the first to collide on `$12` and report `column "id" is of type integer but expression is of type timestamp without time zone` on multi-row inserts.
- The `proposal_type` value retained the leading `/` from the protobuf type URL, which did not match the form expected by the tests.

Also corrects a stale expected value in `TestBigDipperDb_SaveProposals` where the second proposal is created with `nil` messages but the expected `proposal_type` had been copy-pasted from the first proposal.

## Out of scope
- Pre-existing `golangci-lint` violations (G114 / G115 / unused) surfaced after the recent linter version bump are tracked separately and not addressed here.

## Test plan
- [x] `go build ./...`
- [x] `make test-unit` — full suite green locally
- [ ] Node smoke-test: confirm logs emitted under `module=daily_refetch`
- [ ] Audit external dashboards / alerts for any remaining reference to the old `"daily refetch"` label