### PR TITLE
fix: bump wasmvm muslc lib to v2.2.1 to match go.mod

### DIFF
--- a/Dockerfile.cosmwasm
+++ b/Dockerfile.cosmwasm
@@ -4,10 +4,10 @@ WORKDIR /go/src/github.com/forbole/callisto
 COPY . ./
 
 RUN apk update && apk add --no-cache ca-certificates build-base git
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 9ecb037336bd56076573dc18c26631a9d2099a7f2b40dc04b6cae31ffb4c8f9a
-RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 6e4de7ba9bad4ae9679c7f9ecf7e283dd0160e71567c6a7be6ae47c81ebe7f32
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v2.2.1/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v2.2.1/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
+RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep ba6cb5db6b14a265c8556326c045880908db9b1d2ffb5d4aa9f09ac09b24cecc
+RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep b3bd755efac0ff39c01b59b8110f961c48aa3eb93588071d7a628270cc1f2326
 ## Copy the library you want to the final location that will be found by the linker flag `-lwasmvm_muslc`
 RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 RUN go mod download


### PR DESCRIPTION
## Summary
Bump the wasmvm muslc static library fetched in `Dockerfile.cosmwasm` from `v1.1.1` to `v2.2.1`, aligning it with the version declared in `go.mod` (`github.com/CosmWasm/wasmvm/v2 v2.2.1`).

## Background
After PR #12 fixed the Go toolchain version, the docker-build workflow progressed past `go mod download` but failed at `make build` with `undefined reference to ...@GLIBC_*` errors when linking `libwasmvm.x86_64.so` on Alpine/musl.

Root cause: the Dockerfile downloaded the v1.1.1 muslc static lib, so the linker fell back to the glibc-linked `.so` embedded in the v2.2.1 Go module, which is incompatible with musl.

Bumping the muslc lib (and SHA-256 checksums) to v2.2.1 makes the native dependency match the Go module version.

dependency match the Go module version.

Checksums sourced from:
https://github.com/CosmWasm/wasmvm/releases/download/v2.2.1/checksums.txt

## Test plan
- [x] docker-build workflow succeeds after merge to `cosmos/v0.50.x-beta`
- [x] Image `<repo>:cosmos_v0.50.x-beta-<version>` published to Docker Hub
- [x] Verify the image runs against testnet before promoting beta to mainnet