### PR TITLE
chore: promote v0.5.0-alpha7 from beta to mainnet

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,16 +42,16 @@ jobs:
           echo "DOCKERFILE=${DOCKERFILE}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx 🧰
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub 👤
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push 📤
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: "./${{ env.DOCKERFILE }}"

--- a/Dockerfile.cosmwasm
+++ b/Dockerfile.cosmwasm
@@ -4,10 +4,10 @@ WORKDIR /go/src/github.com/forbole/callisto
 COPY . ./
 
 RUN apk update && apk add --no-cache ca-certificates build-base git
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 9ecb037336bd56076573dc18c26631a9d2099a7f2b40dc04b6cae31ffb4c8f9a
-RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 6e4de7ba9bad4ae9679c7f9ecf7e283dd0160e71567c6a7be6ae47c81ebe7f32
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v2.2.1/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v2.2.1/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
+RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep ba6cb5db6b14a265c8556326c045880908db9b1d2ffb5d4aa9f09ac09b24cecc
+RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep b3bd755efac0ff39c01b59b8110f961c48aa3eb93588071d7a628270cc1f2326
 ## Copy the library you want to the final location that will be found by the linker flag `-lwasmvm_muslc`
 RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 RUN go mod download

--- a/Dockerfile.cosmwasm
+++ b/Dockerfile.cosmwasm
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine AS builder
+FROM golang:1.24-alpine AS builder
 RUN apk update && apk add --no-cache make git
 WORKDIR /go/src/github.com/forbole/callisto
 COPY . ./


### PR DESCRIPTION
## Summary
Promote `cosmos/v0.50.x-beta` to `cosmos/v0.50.x` after successful testnet validation of `v0.5.0-alpha7`.

## Changes included
Only the docker-build workflow fixes are promoted (no runtime code changes):

- **#12** — `fix: bring docker-build up to Node.js 24 and Go 1.24`
  - `Dockerfile.cosmwasm` base image `golang:1.20-alpine` → `golang:1.24-alpine`
  - `docker/setup-buildx-action` v3 → v4
  - `docker/login-action` v3 → v4
  - `docker/build-push-action` v5 → v7
- **#13** — `fix: bump wasmvm muslc lib to v2.2.1 to match go.mod`
  - Align native `libwasmvm_muslc` static lib with the `wasmvm/v2 v2.2.1` Go module

## Files changed
- `.github/workflows/docker-build.yml` (+3 / -3)
- `Dockerfile.cosmwasm` (+5 / -5)

## Verification
- [x] Testnet deployment of `v0.5.0-alpha7` running stable on `cosmos/v0.50.x-beta`
- [x] docker-build workflow succeeds end-to-end on beta
- [x] Image pushed to Docker Hub
- [ ] After merge, confirm docker-build runs on `cosmos/v0.50.x` push event